### PR TITLE
Added missing pytest-cookies and environment creation test runs only on Travis-CI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
     - pre-commit==1.14.2
     - pybtex==0.22.2
     - pytest==4.2.0
+    - pytest-cookies==0.3.0
     - pytest-cov==2.6.1
     - pytest-pythonpath==0.7.3
     - sphinx==1.8.3

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import pytest
@@ -73,6 +74,10 @@ def test_remove_travis(cookies):
 @pytest.mark.skipif(
     sys.version_info[:2] != (3, 7),
     reason="Miniconda is only installed for Python 3.7",
+)
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS", "false") != "true",
+    reason="The environment is only created on Travis-CI.",
 )
 def test_check_conda_environment_creation(cookies):
     result = cookies.bake(


### PR DESCRIPTION
This PR addresses two issues:
- ``pytest-cookies`` was missing in ``environment.yml``.
- The test where the environment is created should only run on Travis.